### PR TITLE
Migrate dependencies to using version catalogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,20 +56,20 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.github.elimu-ai:model:model-2.0.83' // See https://jitpack.io/#elimu-ai/model
-    implementation 'com.github.elimu-ai:content-provider:1.2.28@aar' // See https://jitpack.io/#elimu-ai/content-provider
-    implementation 'com.github.elimu-ai:analytics:3.1.27@aar' // See https://jitpack.io/#elimu-ai/analytics
+    implementation libs.elimu.model // See https://jitpack.io/#elimu-ai/model
+    implementation libs.elimu.content.provider // See https://jitpack.io/#elimu-ai/content-provider
+    implementation libs.elimu.analytics // See https://jitpack.io/#elimu-ai/analytics
 
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.constraint.layout
 
-    implementation ('com.sackcentury:shinebutton:1.0.0') {
+    implementation (libs.shine.button) {
         exclude group: 'com.daasuu', module: 'EasingInterpolator'
     }
-    implementation 'com.github.MasayukiSuda:EasingInterpolator:v1.3.2'
+    implementation libs.easing.interpolator
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,27 @@
+[versions]
+elimuModel = "model-2.0.83"
+elimuAnalytics = "3.1.27"
+elimuContentProvider = "1.2.28"
+junit = "4.13.2"
+shineButton = "1.0.0"
+easingInterpolator = "v1.3.2"
+
+constraintLayout = "2.1.3"
+appCompat = "1.4.1"
+androidXJunit = "1.1.3"
+androidXEspresso = "3.4.0"
+
+[libraries]
+elimu-model = { group = "com.github.elimu-ai", name = "model", version.ref = "elimuModel" }
+elimu-analytics = { group = "com.github.elimu-ai", name = "analytics", version.ref = "elimuAnalytics" }
+elimu-content-provider = { group = "com.github.elimu-ai", name = "content-provider", version.ref = "elimuContentProvider" }
+easing-interpolator = { group = "com.github.MasayukiSuda", name = "EasingInterpolator", version.ref = "easingInterpolator" }
+shine-button = { group = "com.sackcentury", name = "shinebutton", version.ref = "shineButton" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appCompat" }
+androidx-constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintLayout" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXJunit" }
+androidx-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidXEspresso" }
+
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+[plugins]


### PR DESCRIPTION
Migrate dependencies to using version catalogs: https://developer.android.com/build/migrate-to-catalogs#groovy