### PR TITLE
Unregister ScreenOnReceiver when the launching service is destroyed

### DIFF
--- a/app/src/main/java/ai/elimu/kukariri/service/ScreenOnService.kt
+++ b/app/src/main/java/ai/elimu/kukariri/service/ScreenOnService.kt
@@ -8,6 +8,9 @@ import android.os.IBinder
 import android.util.Log
 
 class ScreenOnService : Service() {
+
+    private lateinit var screenOnReceiver: ScreenOnReceiver
+
     override fun onBind(intent: Intent): IBinder? {
         return null
     }
@@ -16,9 +19,18 @@ class ScreenOnService : Service() {
         Log.i(javaClass.name, "onStartCommand")
 
         // Register receiver for detecting when the screen is turned on
-        val screenOnReceiver = ScreenOnReceiver()
+        screenOnReceiver = ScreenOnReceiver()
         registerReceiver(screenOnReceiver, IntentFilter(Intent.ACTION_SCREEN_ON))
 
         return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        try {
+            unregisterReceiver(screenOnReceiver)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 }


### PR DESCRIPTION
* Resolves #59 
This depends on https://github.com/elimu-ai/kukariri/pull/58