### PR TITLE
feat: reduce time to wait until 1st review

### DIFF
--- a/app/src/main/java/ai/elimu/kukariri/logic/SpacedRepetitionHelper.java
+++ b/app/src/main/java/ai/elimu/kukariri/logic/SpacedRepetitionHelper.java
@@ -1,7 +1,5 @@
 package ai.elimu.kukariri.logic;
 
-import android.util.Log;
-
 import java.util.Calendar;
 import java.util.List;
 

--- a/app/src/main/java/ai/elimu/kukariri/logic/SpacedRepetitionHelper.java
+++ b/app/src/main/java/ai/elimu/kukariri/logic/SpacedRepetitionHelper.java
@@ -11,6 +11,8 @@ public class SpacedRepetitionHelper {
     /**
      * Verifies that a {@link ai.elimu.model.v2.gson.content.WordGson} has been reviewed (with mastery) 6 times after
      * the original {@link WordLearningEventGson}:
+     *   • After 0.0625 hour (~4 minutes)
+     *   • After 0.25 hour (15 minutes)
      *   • After 1 hour
      *   • After 4 hours
      *   • After 16 hours
@@ -35,7 +37,7 @@ public class SpacedRepetitionHelper {
 
             long milliSecondsPassedSinceWordLearningEvent = Calendar.getInstance().getTimeInMillis() - wordLearningEventGson.getTime().getTimeInMillis();
             Double hoursPassedSinceWordLearningEvent = Double.valueOf(milliSecondsPassedSinceWordLearningEvent / 1000 / 60 / 60);
-            if (hoursPassedSinceWordLearningEvent >= 1.00) {
+            if (hoursPassedSinceWordLearningEvent >= 0.0625) {
                 isReviewPending = true;
             }
         } else {
@@ -63,26 +65,36 @@ public class SpacedRepetitionHelper {
 
                 if (numberOfCorrectReviewsInSequence == 1) {
                     // Check if it's time for the 2nd review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 4.00) {
+                    if (hoursPassedSincePreviousAssessmentEvent >= 0.25) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 2) {
                     // Check if it's time for the 3rd review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 16.00) {
+                    if (hoursPassedSincePreviousAssessmentEvent >= 1.00) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 3) {
                     // Check if it's time for the 4th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 64.00) {
+                    if (hoursPassedSincePreviousAssessmentEvent >= 4.00) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 4) {
                     // Check if it's time for the 5th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 256.00) {
+                    if (hoursPassedSincePreviousAssessmentEvent >= 16.00) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 5) {
                     // Check if it's time for the 6th review
+                    if (hoursPassedSincePreviousAssessmentEvent >= 64.00) {
+                        isReviewPending = true;
+                    }
+                } else if (numberOfCorrectReviewsInSequence == 6) {
+                    // Check if it's time for the 7th review
+                    if (hoursPassedSincePreviousAssessmentEvent >= 256.00) {
+                        isReviewPending = true;
+                    }
+                } else if (numberOfCorrectReviewsInSequence == 7) {
+                    // Check if it's time for the 8th review
                     if (hoursPassedSincePreviousAssessmentEvent >= 1024.00) {
                         isReviewPending = true;
                     }

--- a/app/src/main/java/ai/elimu/kukariri/logic/SpacedRepetitionHelper.java
+++ b/app/src/main/java/ai/elimu/kukariri/logic/SpacedRepetitionHelper.java
@@ -1,5 +1,7 @@
 package ai.elimu.kukariri.logic;
 
+import android.util.Log;
+
 import java.util.Calendar;
 import java.util.List;
 
@@ -11,14 +13,14 @@ public class SpacedRepetitionHelper {
     /**
      * Verifies that a {@link ai.elimu.model.v2.gson.content.WordGson} has been reviewed (with mastery) 6 times after
      * the original {@link WordLearningEventGson}:
-     *   • After 0.0625 hour (~4 minutes)
-     *   • After 0.25 hour (15 minutes)
-     *   • After 1 hour
-     *   • After 4 hours
-     *   • After 16 hours
-     *   • After 64 hours (~3 days)
-     *   • After 256 hours (~11 days)
-     *   • After 1,024 hours (~43 days)
+     *   • After 4 minutes
+     *   • After 16 minutes
+     *   • After 64 minutes (~1 hour)
+     *   • After 256 minutes (~4 hours)
+     *   • After 1,024 minutes (~17 hours)
+     *   • After 4,096 minutes (~3 days)
+     *   • After 16,384 minutes (~11 days)
+     *   • After 65,536 minutes (~46 days)
      *
      * If the student fails to demonstrate mastery during an assessment event, the sequence is restarted from the
      * beginning.
@@ -36,8 +38,8 @@ public class SpacedRepetitionHelper {
             // No reviews have been performed
 
             long milliSecondsPassedSinceWordLearningEvent = Calendar.getInstance().getTimeInMillis() - wordLearningEventGson.getTime().getTimeInMillis();
-            Double hoursPassedSinceWordLearningEvent = Double.valueOf(milliSecondsPassedSinceWordLearningEvent / 1000 / 60 / 60);
-            if (hoursPassedSinceWordLearningEvent >= 0.0625) {
+            Double minutesPassedSinceWordLearningEvent = Double.valueOf(milliSecondsPassedSinceWordLearningEvent / 1000 / 60);
+            if (minutesPassedSinceWordLearningEvent >= 4) {
                 isReviewPending = true;
             }
         } else {
@@ -61,41 +63,41 @@ public class SpacedRepetitionHelper {
 
                 WordAssessmentEventGson previousWordAssessmentEventGson = wordAssessmentEventGsons.get(wordAssessmentEventGsons.size() - 1);
                 long milliSecondsPassedSincePreviousAssessmentEvent = Calendar.getInstance().getTimeInMillis() - previousWordAssessmentEventGson.getTime().getTimeInMillis();
-                Double hoursPassedSincePreviousAssessmentEvent = Double.valueOf(milliSecondsPassedSincePreviousAssessmentEvent / 1000 / 60 / 60);
+                Double minutesPassedSincePreviousAssessmentEvent = Double.valueOf(milliSecondsPassedSincePreviousAssessmentEvent / 1000 / 60);
 
                 if (numberOfCorrectReviewsInSequence == 1) {
                     // Check if it's time for the 2nd review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 0.25) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 16) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 2) {
                     // Check if it's time for the 3rd review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 1.00) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 64) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 3) {
                     // Check if it's time for the 4th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 4.00) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 256) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 4) {
                     // Check if it's time for the 5th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 16.00) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 1_024) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 5) {
                     // Check if it's time for the 6th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 64.00) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 4_096) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 6) {
                     // Check if it's time for the 7th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 256.00) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 16_384) {
                         isReviewPending = true;
                     }
                 } else if (numberOfCorrectReviewsInSequence == 7) {
                     // Check if it's time for the 8th review
-                    if (hoursPassedSincePreviousAssessmentEvent >= 1024.00) {
+                    if (minutesPassedSincePreviousAssessmentEvent >= 65_536) {
                         isReviewPending = true;
                     }
                 }

--- a/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
+++ b/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
@@ -49,29 +49,6 @@ public class SpacedRepetitionHelperTest {
      * Test a time _after_ the time of the initial review (1 hour).
      */
     @Test
-    public void testIsReviewPending_61MinutesAfter_1stReviewFailed() {
-        Calendar calendar61MinutesAgo = Calendar.getInstance();
-        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
-        WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
-        wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar61MinutesAgo);
-
-        Calendar calendarNow = Calendar.getInstance();
-        WordAssessmentEventGson wordAssessmentEventGson = new WordAssessmentEventGson();
-        wordAssessmentEventGson.setWordId(1L);
-        wordAssessmentEventGson.setTime(calendarNow);
-        wordAssessmentEventGson.setMasteryScore(0.00f);
-
-        List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
-        wordAssessmentEventGsonList.add(wordAssessmentEventGson);
-
-        assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsonList), is(true));
-    }
-
-    /**
-     * Test a time _after_ the time of the initial review (1 hour).
-     */
-    @Test
     public void testIsReviewPending_61MinutesAfter_1stReviewNotMastered() {
         Calendar calendar61MinutesAgo = Calendar.getInstance();
         calendar61MinutesAgo.add(Calendar.MINUTE, -61);

--- a/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
+++ b/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
@@ -15,11 +15,11 @@ public class SpacedRepetitionHelperTest {
 
     @Test
     public void testIsReviewPending_59MinutesAfter() {
-        Calendar calendar30MinutesAgo = Calendar.getInstance();
-        calendar30MinutesAgo.add(Calendar.MINUTE, -59);
+        Calendar calendar59MinutesAgo = Calendar.getInstance();
+        calendar59MinutesAgo.add(Calendar.MINUTE, -59);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar30MinutesAgo);
+        wordLearningEventGson.setTime(calendar59MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -28,11 +28,11 @@ public class SpacedRepetitionHelperTest {
 
     @Test
     public void testIsReviewPending_61MinutesAfter() {
-        Calendar calendar30MinutesAgo = Calendar.getInstance();
-        calendar30MinutesAgo.add(Calendar.MINUTE, -61);
+        Calendar calendar61MinutesAgo = Calendar.getInstance();
+        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar30MinutesAgo);
+        wordLearningEventGson.setTime(calendar61MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -61,11 +61,11 @@ public class SpacedRepetitionHelperTest {
 
     @Test
     public void testIsReviewPending_61MinutesAfter_1stReviewNotMastered() {
-        Calendar calendar30MinutesAgo = Calendar.getInstance();
-        calendar30MinutesAgo.add(Calendar.MINUTE, -61);
+        Calendar calendar61MinutesAgo = Calendar.getInstance();
+        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar30MinutesAgo);
+        wordLearningEventGson.setTime(calendar61MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -81,11 +81,11 @@ public class SpacedRepetitionHelperTest {
 
     @Test
     public void testIsReviewPending_61MinutesAfter_1stReviewMastered() {
-        Calendar calendar30MinutesAgo = Calendar.getInstance();
-        calendar30MinutesAgo.add(Calendar.MINUTE, -61);
+        Calendar calendar61MinutesAgo = Calendar.getInstance();
+        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar30MinutesAgo);
+        wordLearningEventGson.setTime(calendar61MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -102,7 +102,7 @@ public class SpacedRepetitionHelperTest {
     @Test
     public void testIsReviewPending_5HoursAfter_MasteryOnFirstTry() {
         Calendar calendar5HoursAgo = Calendar.getInstance();
-        calendar5HoursAgo.add(Calendar.HOUR, -24);
+        calendar5HoursAgo.add(Calendar.HOUR, -5);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
         wordLearningEventGson.setTime(calendar5HoursAgo);
@@ -122,7 +122,7 @@ public class SpacedRepetitionHelperTest {
     @Test
     public void testIsReviewPending_5HoursAfter_MasteryOnSecondTry() {
         Calendar calendar5HoursAgo = Calendar.getInstance();
-        calendar5HoursAgo.add(Calendar.HOUR, -24);
+        calendar5HoursAgo.add(Calendar.HOUR, -5);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
         wordLearningEventGson.setTime(calendar5HoursAgo);

--- a/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
+++ b/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
@@ -14,15 +14,15 @@ import ai.elimu.model.v2.gson.analytics.WordLearningEventGson;
 public class SpacedRepetitionHelperTest {
 
     /**
-     * Test a time _before_ the time of the initial review (1 hour).
+     * Test a time _before_ the time of the initial review (4 minutes).
      */
     @Test
-    public void testIsReviewPending_59MinutesAfter() {
-        Calendar calendar59MinutesAgo = Calendar.getInstance();
-        calendar59MinutesAgo.add(Calendar.MINUTE, -59);
+    public void testIsReviewPending_3MinutesAfter() {
+        Calendar calendar3MinutesAgo = Calendar.getInstance();
+        calendar3MinutesAgo.add(Calendar.MINUTE, -3);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar59MinutesAgo);
+        wordLearningEventGson.setTime(calendar3MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -30,15 +30,15 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the initial review (1 hour).
+     * Test a time _after_ the time of the initial review (4 minutes).
      */
     @Test
-    public void testIsReviewPending_61MinutesAfter() {
-        Calendar calendar61MinutesAgo = Calendar.getInstance();
-        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
+    public void testIsReviewPending_5MinutesAfter() {
+        Calendar calendar5MinutesAgo = Calendar.getInstance();
+        calendar5MinutesAgo.add(Calendar.MINUTE, -5);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar61MinutesAgo);
+        wordLearningEventGson.setTime(calendar5MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -46,15 +46,15 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the initial review (1 hour).
+     * Test a time _after_ the time of the initial review (4 minutes).
      */
     @Test
-    public void testIsReviewPending_61MinutesAfter_1stReviewNotMastered() {
-        Calendar calendar61MinutesAgo = Calendar.getInstance();
-        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
+    public void testIsReviewPending_5MinutesAfter_1stReviewNotMastered() {
+        Calendar calendar5MinutesAgo = Calendar.getInstance();
+        calendar5MinutesAgo.add(Calendar.MINUTE, -5);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar61MinutesAgo);
+        wordLearningEventGson.setTime(calendar5MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -69,15 +69,15 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the initial review (1 hour).
+     * Test a time _after_ the time of the initial review (4 minutes).
      */
     @Test
-    public void testIsReviewPending_61MinutesAfter_1stReviewMastered() {
-        Calendar calendar61MinutesAgo = Calendar.getInstance();
-        calendar61MinutesAgo.add(Calendar.MINUTE, -61);
+    public void testIsReviewPending_5MinutesAfter_1stReviewMastered() {
+        Calendar calendar5MinutesAgo = Calendar.getInstance();
+        calendar5MinutesAgo.add(Calendar.MINUTE, -5);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar61MinutesAgo);
+        wordLearningEventGson.setTime(calendar5MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsonList = new ArrayList<>();
 
@@ -92,15 +92,15 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the 2nd review (4 hours).
+     * Test a time _after_ the time of the 2nd review (16 minutes).
      */
     @Test
-    public void testIsReviewPending_5HoursAfter_MasteryOnFirstTry() {
-        Calendar calendar5HoursAgo = Calendar.getInstance();
-        calendar5HoursAgo.add(Calendar.HOUR, -5);
+    public void testIsReviewPending_17MinutesAfter_MasteryOnFirstTry() {
+        Calendar calendar17MinutesAgo = Calendar.getInstance();
+        calendar17MinutesAgo.add(Calendar.MINUTE, -17);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar5HoursAgo);
+        wordLearningEventGson.setTime(calendar17MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
@@ -115,23 +115,23 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the 2nd review (4 hours).
+     * Test a time _after_ the time of the 2nd review (16 minutes).
      */
     @Test
-    public void testIsReviewPending_5HoursAfter_MasteryOnSecondTry() {
-        Calendar calendar5HoursAgo = Calendar.getInstance();
-        calendar5HoursAgo.add(Calendar.HOUR, -5);
+    public void testIsReviewPending_17MinutesAfter_MasteryOnSecondTry() {
+        Calendar calendar17MinutesAgo = Calendar.getInstance();
+        calendar17MinutesAgo.add(Calendar.MINUTE, -17);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar5HoursAgo);
+        wordLearningEventGson.setTime(calendar17MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
-        Calendar calendar5MinutesAgo = Calendar.getInstance();
-        calendar5MinutesAgo.add(Calendar.MINUTE, -5);
+        Calendar calendar1MinuteAgo = Calendar.getInstance();
+        calendar1MinuteAgo.add(Calendar.MINUTE, -1);
         WordAssessmentEventGson wordAssessmentEventGsonFirst = new WordAssessmentEventGson();
         wordAssessmentEventGsonFirst.setWordId(1L);
-        wordAssessmentEventGsonFirst.setTime(calendar5MinutesAgo);
+        wordAssessmentEventGsonFirst.setTime(calendar1MinuteAgo);
         wordAssessmentEventGsonFirst.setMasteryScore(0.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonFirst);
 
@@ -148,33 +148,33 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the 2nd review (4 hours).
+     * Test a time _after_ the time of the 2nd review (16 minutes).
      */
     @Test
-    public void testIsReviewPending_5HoursAfter_MasteryOnThirdTry() {
-        Calendar calendar5HoursAgo = Calendar.getInstance();
-        calendar5HoursAgo.add(Calendar.HOUR, -5);
+    public void testIsReviewPending_17MinutesAfter_MasteryOnThirdTry() {
+        Calendar calendar17MinutesAgo = Calendar.getInstance();
+        calendar17MinutesAgo.add(Calendar.MINUTE, -17);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar5HoursAgo);
+        wordLearningEventGson.setTime(calendar17MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
-        Calendar calendar10MinutesAgo = Calendar.getInstance();
-        calendar10MinutesAgo.add(Calendar.MINUTE, -10);
+        Calendar calendar2MinutesAgo = Calendar.getInstance();
+        calendar2MinutesAgo.add(Calendar.MINUTE, -2);
         WordAssessmentEventGson wordAssessmentEventGsonFirst = new WordAssessmentEventGson();
         wordAssessmentEventGsonFirst.setWordId(1L);
-        wordAssessmentEventGsonFirst.setTime(calendar10MinutesAgo);
+        wordAssessmentEventGsonFirst.setTime(calendar2MinutesAgo);
         wordAssessmentEventGsonFirst.setMasteryScore(0.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonFirst);
 
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(true));
 
-        Calendar calendar5MinutesAgo = Calendar.getInstance();
-        calendar5MinutesAgo.add(Calendar.MINUTE, -5);
+        Calendar calendar1MinuteAgo = Calendar.getInstance();
+        calendar1MinuteAgo.add(Calendar.MINUTE, -1);
         WordAssessmentEventGson wordAssessmentEventGsonSecond = new WordAssessmentEventGson();
         wordAssessmentEventGsonSecond.setWordId(1L);
-        wordAssessmentEventGsonSecond.setTime(calendar5MinutesAgo);
+        wordAssessmentEventGsonSecond.setTime(calendar1MinuteAgo);
         wordAssessmentEventGsonSecond.setMasteryScore(0.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonSecond);
 
@@ -191,23 +191,23 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _before_ the time of the 2nd review (4 hours).
+     * Test a time _before_ the time of the 2nd review (16 minutes).
      */
     @Test
-    public void testIsReviewPending_false_3Hours59MinutesAfterFirstMastery() {
-        Calendar calendar1DayAgo = Calendar.getInstance();
-        calendar1DayAgo.add(Calendar.DAY_OF_YEAR, -1);
+    public void testIsReviewPending_false_15MinutesAfterFirstMastery() {
+        Calendar calendar60MinutesAgo = Calendar.getInstance();
+        calendar60MinutesAgo.add(Calendar.MINUTE, -60);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar1DayAgo);
+        wordLearningEventGson.setTime(calendar60MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
-        Calendar calendar3Hours59MinutesAgo = Calendar.getInstance();
-        calendar3Hours59MinutesAgo.add(Calendar.MINUTE, -(3*60 + 59));
+        Calendar calendar15MinutesAgo = Calendar.getInstance();
+        calendar15MinutesAgo.add(Calendar.MINUTE, -15);
         WordAssessmentEventGson wordAssessmentEventGsonFirst = new WordAssessmentEventGson();
         wordAssessmentEventGsonFirst.setWordId(1L);
-        wordAssessmentEventGsonFirst.setTime(calendar3Hours59MinutesAgo);
+        wordAssessmentEventGsonFirst.setTime(calendar15MinutesAgo);
         wordAssessmentEventGsonFirst.setMasteryScore(1.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonFirst);
 
@@ -215,23 +215,23 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the 2nd review (4 hours).
+     * Test a time _after_ the time of the 2nd review (16 minutes).
      */
     @Test
-    public void testIsReviewPending_true_4Hours1MinuteAfterFirstMastery() {
-        Calendar calendar1DayAgo = Calendar.getInstance();
-        calendar1DayAgo.add(Calendar.DAY_OF_YEAR, -1);
+    public void testIsReviewPending_true_17MinutesAfterFirstMastery() {
+        Calendar calendar60MinutesAgo = Calendar.getInstance();
+        calendar60MinutesAgo.add(Calendar.MINUTE, -60);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar1DayAgo);
+        wordLearningEventGson.setTime(calendar60MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
-        Calendar calendar4Hours1MinuteAgo = Calendar.getInstance();
-        calendar4Hours1MinuteAgo.add(Calendar.MINUTE, -(4*60 + 1));
+        Calendar calendar17MinutesAgo = Calendar.getInstance();
+        calendar17MinutesAgo.add(Calendar.MINUTE, -17);
         WordAssessmentEventGson wordAssessmentEventGsonFirst = new WordAssessmentEventGson();
         wordAssessmentEventGsonFirst.setWordId(1L);
-        wordAssessmentEventGsonFirst.setTime(calendar4Hours1MinuteAgo);
+        wordAssessmentEventGsonFirst.setTime(calendar17MinutesAgo);
         wordAssessmentEventGsonFirst.setMasteryScore(1.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonFirst);
 
@@ -239,31 +239,31 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _before_ the time of the 3rd review (16 hours).
+     * Test a time _before_ the time of the 3rd review (64 minutes).
      */
     @Test
-    public void testIsReviewPending_false_15Hours59MinutesAfterSecondMastery() {
-        Calendar calendar24HoursAgo = Calendar.getInstance();
-        calendar24HoursAgo.add(Calendar.HOUR, -24);
+    public void testIsReviewPending_false_63MinutesAfterSecondMastery() {
+        Calendar calendar180MinutesAgo = Calendar.getInstance();
+        calendar180MinutesAgo.add(Calendar.MINUTE, -180);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar24HoursAgo);
+        wordLearningEventGson.setTime(calendar180MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
-        Calendar calendar22HoursAgo = Calendar.getInstance();
-        calendar22HoursAgo.add(Calendar.HOUR, -22);
+        Calendar calendar120MinutesAgo = Calendar.getInstance();
+        calendar120MinutesAgo.add(Calendar.MINUTE, -120);
         WordAssessmentEventGson wordAssessmentEventGsonFirst = new WordAssessmentEventGson();
         wordAssessmentEventGsonFirst.setWordId(1L);
-        wordAssessmentEventGsonFirst.setTime(calendar22HoursAgo);
+        wordAssessmentEventGsonFirst.setTime(calendar120MinutesAgo);
         wordAssessmentEventGsonFirst.setMasteryScore(1.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonFirst);
 
-        Calendar calendar15Hours59MinutesAgo = Calendar.getInstance();
-        calendar15Hours59MinutesAgo.add(Calendar.MINUTE, -(15*60 + 59));
+        Calendar calendar63MinutesAgo = Calendar.getInstance();
+        calendar63MinutesAgo.add(Calendar.MINUTE, -63);
         WordAssessmentEventGson wordAssessmentEventGsonSecond = new WordAssessmentEventGson();
         wordAssessmentEventGsonSecond.setWordId(1L);
-        wordAssessmentEventGsonSecond.setTime(calendar15Hours59MinutesAgo);
+        wordAssessmentEventGsonSecond.setTime(calendar63MinutesAgo);
         wordAssessmentEventGsonSecond.setMasteryScore(1.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonSecond);
 
@@ -271,31 +271,31 @@ public class SpacedRepetitionHelperTest {
     }
 
     /**
-     * Test a time _after_ the time of the 3rd review (16 hours).
+     * Test a time _after_ the time of the 3rd review (64 minutes).
      */
     @Test
-    public void testIsReviewPending_true_16Hours1MinuteAfterSecondMastery() {
-        Calendar calendar24HoursAgo = Calendar.getInstance();
-        calendar24HoursAgo.add(Calendar.HOUR, -24);
+    public void testIsReviewPending_true_65MinutesAfterSecondMastery() {
+        Calendar calendar180MinutesAgo = Calendar.getInstance();
+        calendar180MinutesAgo.add(Calendar.MINUTE, -180);
         WordLearningEventGson wordLearningEventGson = new WordLearningEventGson();
         wordLearningEventGson.setWordId(1L);
-        wordLearningEventGson.setTime(calendar24HoursAgo);
+        wordLearningEventGson.setTime(calendar180MinutesAgo);
 
         List<WordAssessmentEventGson> wordAssessmentEventGsons = new ArrayList<>();
 
-        Calendar calendar22HoursAgo = Calendar.getInstance();
-        calendar22HoursAgo.add(Calendar.HOUR, -22);
+        Calendar calendar120MinutesAgo = Calendar.getInstance();
+        calendar120MinutesAgo.add(Calendar.MINUTE, -120);
         WordAssessmentEventGson wordAssessmentEventGsonFirst = new WordAssessmentEventGson();
         wordAssessmentEventGsonFirst.setWordId(1L);
-        wordAssessmentEventGsonFirst.setTime(calendar22HoursAgo);
+        wordAssessmentEventGsonFirst.setTime(calendar120MinutesAgo);
         wordAssessmentEventGsonFirst.setMasteryScore(1.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonFirst);
 
-        Calendar calendar16Hours1MinuteAgo = Calendar.getInstance();
-        calendar16Hours1MinuteAgo.add(Calendar.MINUTE, -(16*60 + 1));
+        Calendar calendar65MinutesAgo = Calendar.getInstance();
+        calendar65MinutesAgo.add(Calendar.MINUTE, -65);
         WordAssessmentEventGson wordAssessmentEventGsonSecond = new WordAssessmentEventGson();
         wordAssessmentEventGsonSecond.setWordId(1L);
-        wordAssessmentEventGsonSecond.setTime(calendar16Hours1MinuteAgo);
+        wordAssessmentEventGsonSecond.setTime(calendar65MinutesAgo);
         wordAssessmentEventGsonSecond.setMasteryScore(1.00f);
         wordAssessmentEventGsons.add(wordAssessmentEventGsonSecond);
 

--- a/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
+++ b/app/src/test/java/ai/elimu/kukariri/logic/SpacedRepetitionHelperTest.java
@@ -13,6 +13,9 @@ import ai.elimu.model.v2.gson.analytics.WordLearningEventGson;
 
 public class SpacedRepetitionHelperTest {
 
+    /**
+     * Test a time _before_ the time of the initial review (1 hour).
+     */
     @Test
     public void testIsReviewPending_59MinutesAfter() {
         Calendar calendar59MinutesAgo = Calendar.getInstance();
@@ -26,6 +29,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsonList), is(false));
     }
 
+    /**
+     * Test a time _after_ the time of the initial review (1 hour).
+     */
     @Test
     public void testIsReviewPending_61MinutesAfter() {
         Calendar calendar61MinutesAgo = Calendar.getInstance();
@@ -39,6 +45,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsonList), is(true));
     }
 
+    /**
+     * Test a time _after_ the time of the initial review (1 hour).
+     */
     @Test
     public void testIsReviewPending_61MinutesAfter_1stReviewFailed() {
         Calendar calendar61MinutesAgo = Calendar.getInstance();
@@ -59,6 +68,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsonList), is(true));
     }
 
+    /**
+     * Test a time _after_ the time of the initial review (1 hour).
+     */
     @Test
     public void testIsReviewPending_61MinutesAfter_1stReviewNotMastered() {
         Calendar calendar61MinutesAgo = Calendar.getInstance();
@@ -79,6 +91,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsonList), is(true));
     }
 
+    /**
+     * Test a time _after_ the time of the initial review (1 hour).
+     */
     @Test
     public void testIsReviewPending_61MinutesAfter_1stReviewMastered() {
         Calendar calendar61MinutesAgo = Calendar.getInstance();
@@ -99,6 +114,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsonList), is(false));
     }
 
+    /**
+     * Test a time _after_ the time of the 2nd review (4 hours).
+     */
     @Test
     public void testIsReviewPending_5HoursAfter_MasteryOnFirstTry() {
         Calendar calendar5HoursAgo = Calendar.getInstance();
@@ -119,6 +137,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(false));
     }
 
+    /**
+     * Test a time _after_ the time of the 2nd review (4 hours).
+     */
     @Test
     public void testIsReviewPending_5HoursAfter_MasteryOnSecondTry() {
         Calendar calendar5HoursAgo = Calendar.getInstance();
@@ -149,6 +170,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(false));
     }
 
+    /**
+     * Test a time _after_ the time of the 2nd review (4 hours).
+     */
     @Test
     public void testIsReviewPending_5HoursAfter_MasteryOnThirdTry() {
         Calendar calendar5HoursAgo = Calendar.getInstance();
@@ -189,6 +213,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(false));
     }
 
+    /**
+     * Test a time _before_ the time of the 2nd review (4 hours).
+     */
     @Test
     public void testIsReviewPending_false_3Hours59MinutesAfterFirstMastery() {
         Calendar calendar1DayAgo = Calendar.getInstance();
@@ -210,6 +237,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(false));
     }
 
+    /**
+     * Test a time _after_ the time of the 2nd review (4 hours).
+     */
     @Test
     public void testIsReviewPending_true_4Hours1MinuteAfterFirstMastery() {
         Calendar calendar1DayAgo = Calendar.getInstance();
@@ -231,6 +261,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(true));
     }
 
+    /**
+     * Test a time _before_ the time of the 3rd review (16 hours).
+     */
     @Test
     public void testIsReviewPending_false_15Hours59MinutesAfterSecondMastery() {
         Calendar calendar24HoursAgo = Calendar.getInstance();
@@ -260,6 +293,9 @@ public class SpacedRepetitionHelperTest {
         assertThat(SpacedRepetitionHelper.isReviewPending(wordLearningEventGson, wordAssessmentEventGsons), is(false));
     }
 
+    /**
+     * Test a time _after_ the time of the 3rd review (16 hours).
+     */
     @Test
     public void testIsReviewPending_true_16Hours1MinuteAfterSecondMastery() {
         Calendar calendar24HoursAgo = Calendar.getInstance();


### PR DESCRIPTION
Resolves #63 

* Reduce waiting time until 1st review from 1 hour to 4 minutes.
* Change smallest time unit from hours to minutes.

More details here: https://github.com/elimu-ai/wiki/blob/main/PEDAGOGY.md

## How to test

1. Open a storybook in the Vitabu app and press one of the underlined words (to report a learning event to the Analytics app)
2. After 4 minutes, the word will appear in the Kukariri app for the 1st review.