### PR TITLE
Make WordContentProvider visible to the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
 
     <queries>
         <provider android:authorities="${analyticsApplicationId}.provider.word_assessment_event_provider" />
+        <provider android:authorities="${contentProviderApplicationId}.provider.word_provider" />
     </queries>
 
     <application


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #95 

### Purpose
Make WordContentProvider visible to the app


### Regression Tests
<!-- Did you verify that your changes didn't break existing functionality? -->
- [ ] I tested my changes on Android 15 (API 35)
- [x] I tested my changes on Android 14 (API 34)
- [ ] I tested my changes on Android 13 (API 33)
- [x] I tested my changes on Android 12L (API 32)
- [ ] I tested my changes on Android 12 (API 31)
- [ ] I tested my changes on Android 11 (API 30)
- [ ] I tested my changes on Android 10 (API 29)
- [ ] I tested my changes on Android 9 (API 28)
- [ ] I tested my changes on Android 8.1 (API 27)
- [ ] I tested my changes on Android 8.0 (API 26)

#### UI Tests
<!-- Did you verify that your changes didn't break existing functionalities on other screen sizes? -->
- [ ] I tested my changes on a 6-7" screen (▯ portrait orientation)
- [ ] I tested my changes on a 6-7" screen (▭ landscape orientation)
- [ ] I tested my changes on a 7-8" screen (▯ portrait orientation)
- [ ] I tested my changes on a 7-8" screen (▭ landscape orientation)
- [ ] I tested my changes on a 9-10" screen (▯ portrait orientation)
- [ ] I tested my changes on a 9-10" screen (▭ landscape orientation)

![](https://github.com/user-attachments/assets/4715d998-db1c-4895-b5bd-4c07c1f34758)
